### PR TITLE
Inconvinient errors handling

### DIFF
--- a/foursquare.js
+++ b/foursquare.js
@@ -28,7 +28,7 @@ module.exports = function(appId, secretKey){
 			req.end();
 
 			req.on('error', function(){
-				return callback(true, 'Trouble with network request to Foursquare');
+				return callback('Trouble with network request to Foursquare');
 			});
 		},
 		_response: function(req, callback){
@@ -45,18 +45,17 @@ module.exports = function(appId, secretKey){
 					response += data;
 				});
 				res.on('end', function(){
-					err = res.statusCode;
+					if (res.statusCode >= 300) err = res.statusCode;
 					try {
 						response = JSON.parse(response);
 					} catch(e) {
-						err = 500;
-						response = "Foursquare did not return JSON";
+						err = 'Foursquare did not return JSON';
 					};
 					return callback(err, response);
 				});
 
 				res.on('error', function(){
-					return callback(true, 'Trouble with network request from Foursquare');
+					return callback('Trouble with network request from Foursquare');
 				});
 			});
 		},
@@ -83,7 +82,7 @@ module.exports = function(appId, secretKey){
 			return path+'client_id='+appId+'&client_secret='+secretKey+'&v=20120928';
 		},
 		fail: function(cb) {
-			cb(true, 'Invalid parameters');
+			cb('Invalid parameters');
 		},
 	};
 	

--- a/tests/foursquare.js
+++ b/tests/foursquare.js
@@ -6,8 +6,8 @@ describe('the foursquare node api', function(){
 	describe('the venues methods', function(){
 		describe('venues#venue()', function(){
 			it('gets a venue', function(done){
-				foursquare.venues.venue('40a55d80f964a52020f31ee3', function(status, resp){
-					assert.equal(200, status);
+				foursquare.venues.venue('40a55d80f964a52020f31ee3', function(err, resp){
+					assert.isUndefined(err);
 					assert.isObject(resp);
 					done();
 				});
@@ -15,8 +15,8 @@ describe('the foursquare node api', function(){
 		});
 		describe('venues#categories()', function(){
 			it('gets categories of venues', function(done){
-				foursquare.venues.categories(function(status, resp){
-					assert.equal(200, status);
+				foursquare.venues.categories(function(err, resp){
+					assert.isUndefined(err);
 					assert.isObject(resp);
 					done();
 				});
@@ -24,8 +24,8 @@ describe('the foursquare node api', function(){
 		});
 		describe('venues#search()', function(){
 			it('gets a list of venues based off a search', function(done){
-				foursquare.venues.search({ll:"40.7,-74", radius:20}, function(status, resp){
-					assert.equal(200, status);
+				foursquare.venues.search({ll:"40.7,-74", radius:20}, function(err, resp){
+					assert.isUndefined(err);
 					assert.isObject(resp);
 					done();
 				});
@@ -33,8 +33,8 @@ describe('the foursquare node api', function(){
 		});
 		describe('venues#explore()', function(){
 			it('gets a list of venues based off a search', function(done){
-				foursquare.venues.explore({ll:"40.7,-74", radius:20}, function(status, resp){
-					assert.equal(200, status);
+				foursquare.venues.explore({ll:"40.7,-74", radius:20}, function(err, resp){
+					assert.isUndefined(err);
 					assert.isObject(resp);
 					done();
 				});
@@ -42,8 +42,8 @@ describe('the foursquare node api', function(){
 		});
 		describe('venues#suggestcompletion()', function(){
 			it('suggestion autocompletion', function(done){
-				foursquare.venues.suggestcompletion({ll:"44.3,37.2", query: "foursq"}, function(status, resp){
-					assert.equal(200, status);
+				foursquare.venues.suggestcompletion({ll:"44.3,37.2", query: "foursq"}, function(err, resp){
+					assert.isUndefined(err);
 					assert.isObject(resp);
 					done();
 				});
@@ -51,8 +51,8 @@ describe('the foursquare node api', function(){
 		});
 		describe('venues#trending()', function(){
 			it('returns a list of trending venues in the area', function(done){
-				foursquare.venues.trending({ll:"44.3,37.2", limit: 20}, function(status, resp){
-					assert.equal(200, status);
+				foursquare.venues.trending({ll:"44.3,37.2", limit: 20}, function(err, resp){
+					assert.isUndefined(err);
 					assert.isObject(resp);
 					done();
 				});
@@ -60,8 +60,8 @@ describe('the foursquare node api', function(){
 		});
 		describe('venues#events()', function(){
 			it('returns a list of events happening at the venue', function(done){
-				foursquare.venues.events('40a55d80f964a52020f31ee3', function(status, resp){
-					assert.equal(200, status);
+				foursquare.venues.events('40a55d80f964a52020f31ee3', function(err, resp){
+					assert.isUndefined(err);
 					assert.isObject(resp);
 					done();
 				});
@@ -69,8 +69,8 @@ describe('the foursquare node api', function(){
 		});
 		describe('venues#hours()', function(){
 			it('returns the operating hours at the venue', function(done){
-				foursquare.venues.hours('40a55d80f964a52020f31ee3', function(status, resp){
-					assert.equal(200, status);
+				foursquare.venues.hours('40a55d80f964a52020f31ee3', function(err, resp){
+					assert.isUndefined(err);
 					assert.isObject(resp);
 					done();
 				});
@@ -78,8 +78,8 @@ describe('the foursquare node api', function(){
 		});
 		describe('venues#likes()', function(){
 			it('returns the number of likes for the venue', function(done){
-				foursquare.venues.likes('40a55d80f964a52020f31ee3', function(status, resp){
-					assert.equal(200, status);
+				foursquare.venues.likes('40a55d80f964a52020f31ee3', function(err, resp){
+					assert.isUndefined(err);
 					assert.isObject(resp);
 					done();
 				});
@@ -87,8 +87,8 @@ describe('the foursquare node api', function(){
 		});
 		describe('venues#links()', function(){
 			it('returns a list of links for the venue', function(done){
-				foursquare.venues.links('40a55d80f964a52020f31ee3', function(status, resp){
-					assert.equal(200, status);
+				foursquare.venues.links('40a55d80f964a52020f31ee3', function(err, resp){
+					assert.isUndefined(err);
 					assert.isObject(resp);
 					done();
 				});
@@ -96,8 +96,8 @@ describe('the foursquare node api', function(){
 		});
 		describe('venues#listed()', function(){
 			it('returns ids of lists the venue is on', function(done){
-				foursquare.venues.listed('40a55d80f964a52020f31ee3', {group:"other"}, function(status, resp){
-					assert.equal(200, status);
+				foursquare.venues.listed('40a55d80f964a52020f31ee3', {group:"other"}, function(err, resp){
+					assert.isUndefined(err);
 					assert.isObject(resp);
 					done();
 				});
@@ -105,8 +105,8 @@ describe('the foursquare node api', function(){
 		});
 		describe('venues#menu()', function(){
 			it('returns the menu if the venue has one', function(done){
-				foursquare.venues.menu('40a55d80f964a52020f31ee3', function(status, resp){
-					assert.equal(200, status);
+				foursquare.venues.menu('40a55d80f964a52020f31ee3', function(err, resp){
+					assert.isUndefined(err);
 					assert.isObject(resp);
 					done();
 				});
@@ -114,8 +114,8 @@ describe('the foursquare node api', function(){
 		});
 		describe('venues#photos()', function(){
 			it('returns photos of the venue', function(done){
-				foursquare.venues.photos('40a55d80f964a52020f31ee3', {group:"venue"}, function(status, resp){
-					assert.equal(200, status);
+				foursquare.venues.photos('40a55d80f964a52020f31ee3', {group:"venue"}, function(err, resp){
+					assert.isUndefined(err);
 					assert.isObject(resp);
 					done();
 				});
@@ -123,8 +123,8 @@ describe('the foursquare node api', function(){
 		});
 		describe('venues#tips()', function(){
 			it('returns the venues tips', function(done){
-				foursquare.venues.tips('40a55d80f964a52020f31ee3', {sort:"recent"}, function(status, resp){
-					assert.equal(200, status);
+				foursquare.venues.tips('40a55d80f964a52020f31ee3', {sort:"recent"}, function(err, resp){
+					assert.isUndefined(err);
 					assert.isObject(resp);
 					done();
 				});
@@ -134,8 +134,8 @@ describe('the foursquare node api', function(){
 	describe('the tips methods', function(){
 		describe('tips#search()', function(){
 			it('gets tips based of a query', function(done){
-				foursquare.tips.search({ll:"44.3,37.2"}, function(status, resp){
-					assert.equal(200, status);
+				foursquare.tips.search({ll:"44.3,37.2"}, function(err, resp){
+					assert.isUndefined(err);
 					assert.isObject(resp);
 					done();
 				});
@@ -143,8 +143,8 @@ describe('the foursquare node api', function(){
 		});
 		describe('tips#search()', function(){
 			it('gets tips based of a query', function(done){
-				foursquare.tips.search({ll:"44.3,37.2"}, function(status, resp){
-					assert.equal(200, status);
+				foursquare.tips.search({ll:"44.3,37.2"}, function(err, resp){
+					assert.isUndefined(err);
 					assert.isObject(resp);
 					done();
 				});
@@ -152,8 +152,8 @@ describe('the foursquare node api', function(){
 		});
 		describe('tips#done()', function(){
 			it('Returns an array of users have done this tip', function(done){
-				foursquare.tips.done('4e5b969ab61c4aaa3e183989', {limit:"10"}, function(status, resp){
-					assert.equal(200, status);
+				foursquare.tips.done('4e5b969ab61c4aaa3e183989', {limit:"10"}, function(err, resp){
+					assert.isUndefined(err);
 					assert.isObject(resp);
 					done();
 				});
@@ -161,8 +161,8 @@ describe('the foursquare node api', function(){
 		});
 		describe('tips#likes()', function(){
 			it('Returns friends and a total count of users who have liked this tip', function(done){
-				foursquare.tips.likes('4e5b969ab61c4aaa3e183989', function(status, resp){
-					assert.equal(200, status);
+				foursquare.tips.likes('4e5b969ab61c4aaa3e183989', function(err, resp){
+					assert.isUndefined(err);
 					assert.isObject(resp);
 					done();
 				});
@@ -170,8 +170,8 @@ describe('the foursquare node api', function(){
 		});
 		describe('tips#listed()', function(){
 			it('The lists that this tip appears on', function(done){
-				foursquare.tips.listed('4e5b969ab61c4aaa3e183989', {group:"other"}, function(status, resp){
-					assert.equal(200, status);
+				foursquare.tips.listed('4e5b969ab61c4aaa3e183989', {group:"other"}, function(err, resp){
+					assert.isUndefined(err);
 					assert.isObject(resp);
 					done();
 				});
@@ -181,8 +181,8 @@ describe('the foursquare node api', function(){
 	describe('the lists methods', function(){
 		describe('lists#detail()', function(){
 			it('Gives details about a list', function(done){
-				foursquare.lists.detail('50661c87e4b0679acac1d7e9', {limit:"20"}, function(status, resp){
-					assert.equal(200, status);
+				foursquare.lists.detail('50661c87e4b0679acac1d7e9', {limit:"20"}, function(err, resp){
+					assert.isUndefined(err);
 					assert.isObject(resp);
 					done();
 				});
@@ -190,8 +190,8 @@ describe('the foursquare node api', function(){
 		});
 		describe('lists#followers()', function(){
 			it('Returns a count and items of users following this list. ', function(done){
-				foursquare.lists.followers('50661c87e4b0679acac1d7e9', function(status, resp){
-					assert.equal(200, status);
+				foursquare.lists.followers('50661c87e4b0679acac1d7e9', function(err, resp){
+					assert.isUndefined(err);
 					assert.isObject(resp);
 					done();
 				});
@@ -201,8 +201,8 @@ describe('the foursquare node api', function(){
 	describe('specials methods', function(){
 		describe('specials#detail()', function(){
 			it('Gives details about a special', function(done){
-				foursquare.specials.detail('4e0debea922e6f94b1410bb7', {venueId:'4e0deab3922e6f94b1410af3'}, function(status, resp){
-					assert.equal(200, status);
+				foursquare.specials.detail('4e0debea922e6f94b1410bb7', {venueId:'4e0deab3922e6f94b1410af3'}, function(err, resp){
+					assert.isUndefined(err);
 					assert.isObject(resp);
 					done();
 				});
@@ -210,8 +210,8 @@ describe('the foursquare node api', function(){
 		});
 		describe('specials#search()', function(){
 			it('searches for specials', function(done){
-				foursquare.specials.search({ll:"44.3,37.2"}, function(status, resp){
-					assert.equal(200, status);
+				foursquare.specials.search({ll:"44.3,37.2"}, function(err, resp){
+					assert.isUndefined(err);
 					assert.isObject(resp);
 					done();
 				});
@@ -221,8 +221,8 @@ describe('the foursquare node api', function(){
 	describe('events methods', function(){
 		describe('events#categories()', function(){
 			it('Returns a hierarchical list of categories applied to events', function(done){
-				foursquare.events.categories(function(status, resp){
-					assert.equal(200, status);
+				foursquare.events.categories(function(err, resp){
+					assert.isUndefined(err);
 					assert.isObject(resp);
 					done();
 				});
@@ -230,8 +230,8 @@ describe('the foursquare node api', function(){
 		});
 		describe('events#search()', function(){
 			it('Returns a hierarchical list of categories applied to events', function(done){
-				foursquare.events.search({domain:"songkick.com", eventId:"8183976"}, function(status, resp){
-					assert.equal(200, status);
+				foursquare.events.search({domain:"songkick.com", eventId:"8183976"}, function(err, resp){
+					assert.isUndefined(err);
 					assert.isObject(resp);
 					done();
 				});
@@ -241,8 +241,8 @@ describe('the foursquare node api', function(){
 	describe('pages methods', function(){
 		describe('pages#venues()', function(){
 			it('Allows you to get the page\'s venues', function(done){
-				foursquare.pages.venues('1070527', {ll:"44.3,37.2"}, function(status, resp){
-					assert.equal(200, status);
+				foursquare.pages.venues('1070527', {ll:"44.3,37.2"}, function(err, resp){
+					assert.isUndefined(err);
 					assert.isObject(resp);
 					done();
 				});


### PR DESCRIPTION
In node.js first argument of any callback function represents an error and should follow some rules:
- It should always be `null` if request completed successfully.
- It should describe an error otherwise.

The main problem is that all node.js libraries and frameworks for handling asynchronous workflow expect it to be so.

Passing `200` instead of `null` is against node.js callbacks convention, and it breaks any code written according to it.

**N.B.** It's also [a good practice](http://www.devthought.com/2011/12/22/a-string-is-not-an-error/) to wrap all errors using `new Error` constructor in order to capture stacktrace.
