### PR TITLE
adds search object parameter to individual venue fetch function

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ All methods take a callback as their last parameter.
 A `searchObj` is an object containing the properties [outlined here.](https://developer.foursquare.com/docs/venues/search)
 
 * `foursquare.venues`
-   * `.venue(venueId, callback)`
+   * `.venue(venueId, searchObj, callback)`
    * `.categories(callback)`
    * `.search(searchObj, callback)`
    * `.explore(searchObj, callback)`

--- a/foursquare.js
+++ b/foursquare.js
@@ -88,9 +88,9 @@ module.exports = function(appId, secretKey){
 	
 	return {
 		venues: {
-			venue: function(venueId, callback){
+			venue: function(venueId, infoObj, callback){
 				if (!venueId || !callback) return fourSquare.fail(callback);
-				fourSquare.get(fourSquare.query('/venues/'+venueId), callback);
+				fourSquare.get(fourSquare.query('/venues/'+venueId, infoObj), callback);
 			},
 			categories: function(callback){
 				if (!callback) return fourSquare.fail(callback);


### PR DESCRIPTION
Certain aspects of the venue data model (e.g. 'distance') are only returned when the lat / long are included in the request. This fix allows users to include optional parameters, such as lat / long, similar to the search and explore calls.
